### PR TITLE
Replace toast innerHTML usage with textContent

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,7 +474,9 @@
                 const toastElement = document.createElement('div');
                 toastElement.id = toastId;
                 toastElement.className = `w-full max-w-sm p-4 text-white rounded-lg shadow-xl ${colors[type]} toast-enter`;
-                toastElement.innerHTML = `<p>${icon} ${message}</p>`;
+                const toastMessage = document.createElement('p');
+                toastMessage.textContent = `${icon} ${message}`;
+                toastElement.appendChild(toastMessage);
                 
                 toastContainer.appendChild(toastElement);
 


### PR DESCRIPTION
## Summary
- replace the toast message innerHTML usage with DOM element creation and textContent assignment to avoid injecting HTML

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97d924f9083299ec2e89f6b9b515c