### PR TITLE
Validate image uploads before submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,6 +364,32 @@
 
 
             // --- FUNCTIONS ---
+            const IMAGE_FILE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'tif', 'tiff', 'svg', 'heic', 'heif', 'avif']);
+
+            const isValidImageFile = (file) => {
+                if (!file) return false;
+                if (file.type && file.type.startsWith('image/')) return true;
+                const fileName = file.name || '';
+                const extension = fileName.includes('.') ? fileName.split('.').pop().toLowerCase() : '';
+                return IMAGE_FILE_EXTENSIONS.has(extension);
+            };
+
+            const clearSelectedFile = () => {
+                const fileInput = document.getElementById('photo-upload-input');
+                if (fileInput) {
+                    fileInput.value = '';
+                }
+                const previewImage = document.getElementById('photo-preview');
+                if (previewImage) {
+                    previewImage.src = '';
+                }
+                const previewContainer = document.getElementById('photo-preview-container');
+                if (previewContainer) {
+                    previewContainer.classList.add('hidden');
+                }
+                selectedFile = null;
+            };
+
             const getGeolocation = () => {
                 if (navigator.geolocation) {
                     navigator.geolocation.getCurrentPosition(
@@ -419,12 +445,11 @@
 
             const resetForm = () => {
                 feedbackForm.reset();
-                document.getElementById('photo-preview-container').classList.add('hidden');
+                clearSelectedFile();
                 document.getElementById('ai-results-section').classList.add('hidden');
-                document.getElementById('product-suggestions').innerHTML = '';
-                document.getElementById('product-suggestions').classList.add('hidden');
-                document.getElementById('photo-preview').src = '';
-                selectedFile = null;
+                const suggestionsEl = document.getElementById('product-suggestions');
+                suggestionsEl.innerHTML = '';
+                suggestionsEl.classList.add('hidden');
                 currentCategory = '';
                 satisfactionRating = 0;
                 userGeolocation = null;
@@ -432,16 +457,28 @@
             };
             
             const handleFileSelect = (event) => {
-                const file = event.target.files[0];
-                if (file) {
-                    selectedFile = file;
-                    const reader = new FileReader();
-                    reader.onload = (e) => {
-                        document.getElementById('photo-preview').src = e.target.result;
-                        document.getElementById('photo-preview-container').classList.remove('hidden');
-                    };
-                    reader.readAsDataURL(file);
+                const fileInput = event.target;
+                const file = fileInput.files[0];
+
+                if (!file) {
+                    clearSelectedFile();
+                    return;
                 }
+
+                if (!isValidImageFile(file)) {
+                    console.warn('Rejected file selection: not an image.', { fileName: file.name, fileType: file.type });
+                    showToast('Дозволено завантажувати лише файли зображень.', 'error');
+                    clearSelectedFile();
+                    return;
+                }
+
+                selectedFile = file;
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    document.getElementById('photo-preview').src = e.target.result;
+                    document.getElementById('photo-preview-container').classList.remove('hidden');
+                };
+                reader.readAsDataURL(file);
             };
             
             const showLoading = (isLoading, element = 'submit') => {
@@ -466,18 +503,19 @@
             
             const showToast = (message, type = 'success') => {
                 const toastId = `toast-${Date.now()}`;
-                const colors = {
-                    success: 'bg-green-500',
-                    achievement: 'bg-yellow-500'
+                const toastStyles = {
+                    success: { color: 'bg-green-500', icon: '✅' },
+                    achievement: { color: 'bg-yellow-500', icon: '🏆' },
+                    error: { color: 'bg-red-500', icon: '⚠️' }
                 };
-                const icon = type === 'achievement' ? '🏆' : '✅';
+                const { color, icon } = toastStyles[type] || toastStyles.success;
                 const toastElement = document.createElement('div');
                 toastElement.id = toastId;
-                toastElement.className = `w-full max-w-sm p-4 text-white rounded-lg shadow-xl ${colors[type]} toast-enter`;
+                toastElement.className = `w-full max-w-sm p-4 text-white rounded-lg shadow-xl ${color} toast-enter`;
                 const toastMessage = document.createElement('p');
                 toastMessage.textContent = `${icon} ${message}`;
                 toastElement.appendChild(toastMessage);
-                
+
                 toastContainer.appendChild(toastElement);
 
                 setTimeout(() => {
@@ -526,6 +564,17 @@
             };
 
             const uploadToImageKit = (file) => {
+                if (!file) {
+                    return Promise.resolve(null);
+                }
+
+                if (!isValidImageFile(file)) {
+                    console.warn('Skipping upload to ImageKit: file is not a supported image.', { fileName: file.name, fileType: file.type });
+                    showToast('Файл не відповідає вимогам зображення і не буде надісланий.', 'error');
+                    clearSelectedFile();
+                    return Promise.resolve(null);
+                }
+
                 return new Promise((resolve, reject) => {
                     imagekit.upload({
                         file: file,


### PR DESCRIPTION
## Summary
- add helpers to validate uploaded files by MIME type and file extension
- reset the selection and show an error toast when a non-image file is chosen
- skip ImageKit uploads for invalid files and log the rejection for support visibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9b98d0fb48329865bf495ba867bc2