### PR TITLE
Fix achievements modal reopen animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,6 +776,7 @@
             achievementsBtn.addEventListener('click', () => {
                 renderAchievements();
                 achievementsModal.classList.remove('hidden');
+                achievementsModal.classList.remove('modal-leave');
                 achievementsModal.classList.add('modal-enter');
             });
             closeAchievementsModalBtn.addEventListener('click', () => closeModal(achievementsModal));


### PR DESCRIPTION
## Summary
- ensure the achievements modal removes the exit animation class before playing the enter animation so it reopens correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9beaf48f48329946dc70adde3ac1b