### PR TITLE
Add camera capture attribute for photo upload

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,13 +243,13 @@
                 
                 <div id="photo-upload-section" class="hidden mb-4">
                      <label for="photo-upload-btn" class="block text-sm font-medium text-gray-700 mb-1">Прикріпити фото:</label>
-                     <input type="file" id="photo-upload-input" class="hidden" accept="image/*">
+                     <input type="file" id="photo-upload-input" class="hidden" accept="image/*" capture="environment">
                      <button type="button" id="photo-upload-btn" class="w-full flex items-center justify-center gap-2 p-3 border-2 border-dashed border-gray-300 rounded-lg text-gray-500 hover:bg-gray-50 hover:border-orange-500 hover:text-orange-600 transition">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                           <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
                           <path stroke-linecap="round" stroke-linejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
                         </svg>
-                        <span>Обрати файл</span>
+                        <span>Зробити фото або обрати файл</span>
                      </button>
                      <div id="photo-preview-container" class="mt-4 hidden">
                          <img id="photo-preview" src="" alt="Photo preview" class="max-h-40 rounded-lg mx-auto"/>


### PR DESCRIPTION
## Summary
- add the `capture="environment"` attribute to the photo upload input so Android browsers offer the rear camera
- update the photo upload button text to clarify that a photo can be taken or a file can be chosen

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9df5abc1c8329a1e12314f40b48bc