### PR TITLE
Ensure achievements modal animation resets

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,17 +703,20 @@
                 `;
                 achievementsList.innerHTML = achievementHTML;
             };
+
+            const openAchievementsModal = () => {
+                renderAchievements();
+                achievementsModal.classList.remove('hidden');
+                achievementsModal.classList.remove('modal-leave');
+                achievementsModal.classList.add('modal-enter');
+            };
             
             // --- EVENT LISTENERS BINDING ---
             categoryButtons.forEach(button => button.addEventListener('click', () => openModal(button.dataset.category)));
             closeModalBtn.addEventListener('click', () => closeModal(modal));
             modal.addEventListener('click', (e) => { if (e.target.id === 'feedback-modal') closeModal(modal); });
             
-            achievementsBtn.addEventListener('click', () => {
-                renderAchievements();
-                achievementsModal.classList.remove('hidden');
-                achievementsModal.classList.add('modal-enter');
-            });
+            achievementsBtn.addEventListener('click', openAchievementsModal);
             closeAchievementsModalBtn.addEventListener('click', () => closeModal(achievementsModal));
             achievementsModal.addEventListener('click', (e) => { if (e.target.id === 'achievements-modal') closeModal(achievementsModal); });
 


### PR DESCRIPTION
## Summary
- ensure the achievements modal removes the exit animation class before triggering the enter animation
- centralize achievements modal opening logic so all entry points reuse the same animation reset

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd23e42f588329bb3da5efa121e101