### PR TITLE
Adjust light theme form field colors for mobile

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -12,6 +12,46 @@
   html.dark body {
     background: linear-gradient(135deg, #0f172a 0%, #1f2937 100%);
   }
+
+  input,
+  select,
+  textarea {
+    color: inherit;
+  }
+
+  html:not(.dark) input,
+  html:not(.dark) select,
+  html:not(.dark) textarea {
+    color-scheme: light;
+    background-color: rgba(255, 255, 255, 0.95);
+    color: #1f2937;
+  }
+
+  html:not(.dark) input::placeholder,
+  html:not(.dark) textarea::placeholder {
+    color: rgba(100, 116, 139, 0.85);
+  }
+
+  html.dark input,
+  html.dark select,
+  html.dark textarea {
+    color-scheme: dark;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html:not(.dark) input,
+    html:not(.dark) select,
+    html:not(.dark) textarea {
+      background-color: #1f2937;
+      color: #f8fafc;
+      border-color: rgba(148, 163, 184, 0.4);
+    }
+
+    html:not(.dark) input::placeholder,
+    html:not(.dark) textarea::placeholder {
+      color: rgba(226, 232, 240, 0.75);
+    }
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- ensure form inputs and text areas use a light color scheme in light mode so typed text stays visible
- add dark OS preference overrides that force contrasting text and placeholder colors when the app is in light theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ce0665648329ac774f1b2ab53139